### PR TITLE
Query downstream targets of drugs and upstream controllers of proteins with INDRA

### DIFF
--- a/Module4.ipynb
+++ b/Module4.ipynb
@@ -1,0 +1,511 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "9f9b7e66-acf6-443a-a729-a67622b5931f",
+   "metadata": {},
+   "source": [
+    "# Hands on: Exploring literature-derived networks for data interpretation with INDRA"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "505a7b3f-bf79-42ff-a82a-8c2e1277a304",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -q -r requirements.txt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1f0c61ae-e8ff-440f-a5c7-7f9fb9e74ba0",
+   "metadata": {},
+   "source": [
+    "## 1. Introduction"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fc9b0fe1-9467-4b53-9166-5cd064b8c1e1",
+   "metadata": {},
+   "source": [
+    "### Recall - Example Dataset"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3492763c-f6b9-492c-bd8f-047089c8ec3c",
+   "metadata": {},
+   "source": [
+    "We use an example dataset produced from an MSstats differential abundance analysis.  This dataset is a small molecule dataset with known inhibition targets.  It includes 8 small molecule inhibitors and a control DMSO holdout. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "9b84c8d6-faaf-46e2-a190-98a7b17a659c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>RUN</th>\n",
+       "      <th>Protein</th>\n",
+       "      <th>LogIntensities</th>\n",
+       "      <th>originalRUN</th>\n",
+       "      <th>GROUP</th>\n",
+       "      <th>SUBJECT</th>\n",
+       "      <th>TotalGroupMeasurements</th>\n",
+       "      <th>NumMeasuredFeature</th>\n",
+       "      <th>MissingPercentage</th>\n",
+       "      <th>more50missing</th>\n",
+       "      <th>NumImputedFeature</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "      <td>1433B_HUMAN</td>\n",
+       "      <td>12.873423</td>\n",
+       "      <td>230719_THP-1_Chrom_end2end_Plate1_DMSO_A02_DIA</td>\n",
+       "      <td>DMSO</td>\n",
+       "      <td>2</td>\n",
+       "      <td>1210</td>\n",
+       "      <td>10</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2</td>\n",
+       "      <td>1433B_HUMAN</td>\n",
+       "      <td>12.866217</td>\n",
+       "      <td>230719_THP-1_Chrom_end2end_Plate1_DMSO_A05_DIA</td>\n",
+       "      <td>DMSO</td>\n",
+       "      <td>5</td>\n",
+       "      <td>1210</td>\n",
+       "      <td>10</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>3</td>\n",
+       "      <td>1433B_HUMAN</td>\n",
+       "      <td>12.686827</td>\n",
+       "      <td>230719_THP-1_Chrom_end2end_Plate1_DMSO_A10_DIA</td>\n",
+       "      <td>DMSO</td>\n",
+       "      <td>10</td>\n",
+       "      <td>1210</td>\n",
+       "      <td>10</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>4</td>\n",
+       "      <td>1433B_HUMAN</td>\n",
+       "      <td>12.625462</td>\n",
+       "      <td>230719_THP-1_Chrom_end2end_Plate1_DMSO_A12_DIA</td>\n",
+       "      <td>DMSO</td>\n",
+       "      <td>12</td>\n",
+       "      <td>1210</td>\n",
+       "      <td>10</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>5</td>\n",
+       "      <td>1433B_HUMAN</td>\n",
+       "      <td>12.538365</td>\n",
+       "      <td>230719_THP-1_Chrom_end2end_Plate1_DMSO_B01_DIA</td>\n",
+       "      <td>DMSO</td>\n",
+       "      <td>13</td>\n",
+       "      <td>1210</td>\n",
+       "      <td>10</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1189821</th>\n",
+       "      <td>266</td>\n",
+       "      <td>ZZZ3_HUMAN</td>\n",
+       "      <td>10.384438</td>\n",
+       "      <td>230719_THP-1_Chrom_end2end_Plate3_DMSO_A10</td>\n",
+       "      <td>VTP50469</td>\n",
+       "      <td>202</td>\n",
+       "      <td>170</td>\n",
+       "      <td>10</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1189822</th>\n",
+       "      <td>267</td>\n",
+       "      <td>ZZZ3_HUMAN</td>\n",
+       "      <td>10.231615</td>\n",
+       "      <td>230719_THP-1_Chrom_end2end_Plate3_DMSO_B03</td>\n",
+       "      <td>VTP50469</td>\n",
+       "      <td>207</td>\n",
+       "      <td>170</td>\n",
+       "      <td>10</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1189823</th>\n",
+       "      <td>268</td>\n",
+       "      <td>ZZZ3_HUMAN</td>\n",
+       "      <td>10.502691</td>\n",
+       "      <td>230719_THP-1_Chrom_end2end_Plate3_DbET6_C07</td>\n",
+       "      <td>VTP50469</td>\n",
+       "      <td>223</td>\n",
+       "      <td>170</td>\n",
+       "      <td>10</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1189824</th>\n",
+       "      <td>269</td>\n",
+       "      <td>ZZZ3_HUMAN</td>\n",
+       "      <td>10.674776</td>\n",
+       "      <td>230719_THP-1_Chrom_end2end_Plate3_DMSO_C11</td>\n",
+       "      <td>VTP50469</td>\n",
+       "      <td>227</td>\n",
+       "      <td>170</td>\n",
+       "      <td>10</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1189825</th>\n",
+       "      <td>270</td>\n",
+       "      <td>ZZZ3_HUMAN</td>\n",
+       "      <td>10.531401</td>\n",
+       "      <td>230719_THP-1_Chrom_end2end_Plate3_Jakafi_E02</td>\n",
+       "      <td>VTP50469</td>\n",
+       "      <td>242</td>\n",
+       "      <td>170</td>\n",
+       "      <td>10</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>1189826 rows × 11 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "         RUN      Protein  LogIntensities  \\\n",
+       "0          1  1433B_HUMAN       12.873423   \n",
+       "1          2  1433B_HUMAN       12.866217   \n",
+       "2          3  1433B_HUMAN       12.686827   \n",
+       "3          4  1433B_HUMAN       12.625462   \n",
+       "4          5  1433B_HUMAN       12.538365   \n",
+       "...      ...          ...             ...   \n",
+       "1189821  266   ZZZ3_HUMAN       10.384438   \n",
+       "1189822  267   ZZZ3_HUMAN       10.231615   \n",
+       "1189823  268   ZZZ3_HUMAN       10.502691   \n",
+       "1189824  269   ZZZ3_HUMAN       10.674776   \n",
+       "1189825  270   ZZZ3_HUMAN       10.531401   \n",
+       "\n",
+       "                                            originalRUN     GROUP  SUBJECT  \\\n",
+       "0        230719_THP-1_Chrom_end2end_Plate1_DMSO_A02_DIA      DMSO        2   \n",
+       "1        230719_THP-1_Chrom_end2end_Plate1_DMSO_A05_DIA      DMSO        5   \n",
+       "2        230719_THP-1_Chrom_end2end_Plate1_DMSO_A10_DIA      DMSO       10   \n",
+       "3        230719_THP-1_Chrom_end2end_Plate1_DMSO_A12_DIA      DMSO       12   \n",
+       "4        230719_THP-1_Chrom_end2end_Plate1_DMSO_B01_DIA      DMSO       13   \n",
+       "...                                                 ...       ...      ...   \n",
+       "1189821      230719_THP-1_Chrom_end2end_Plate3_DMSO_A10  VTP50469      202   \n",
+       "1189822      230719_THP-1_Chrom_end2end_Plate3_DMSO_B03  VTP50469      207   \n",
+       "1189823     230719_THP-1_Chrom_end2end_Plate3_DbET6_C07  VTP50469      223   \n",
+       "1189824      230719_THP-1_Chrom_end2end_Plate3_DMSO_C11  VTP50469      227   \n",
+       "1189825    230719_THP-1_Chrom_end2end_Plate3_Jakafi_E02  VTP50469      242   \n",
+       "\n",
+       "         TotalGroupMeasurements  NumMeasuredFeature  MissingPercentage  \\\n",
+       "0                          1210                  10                0.0   \n",
+       "1                          1210                  10                0.0   \n",
+       "2                          1210                  10                0.0   \n",
+       "3                          1210                  10                0.0   \n",
+       "4                          1210                  10                0.0   \n",
+       "...                         ...                 ...                ...   \n",
+       "1189821                     170                  10                0.0   \n",
+       "1189822                     170                  10                0.0   \n",
+       "1189823                     170                  10                0.0   \n",
+       "1189824                     170                  10                0.0   \n",
+       "1189825                     170                  10                0.0   \n",
+       "\n",
+       "         more50missing  NumImputedFeature  \n",
+       "0                False                  0  \n",
+       "1                False                  0  \n",
+       "2                False                  0  \n",
+       "3                False                  0  \n",
+       "4                False                  0  \n",
+       "...                ...                ...  \n",
+       "1189821          False                  0  \n",
+       "1189822          False                  0  \n",
+       "1189823          False                  0  \n",
+       "1189824          False                  0  \n",
+       "1189825          False                  0  \n",
+       "\n",
+       "[1189826 rows x 11 columns]"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "DATA_PATH = \"dataProcessOutput.csv\"\n",
+    "\n",
+    "def import_data(filename):\n",
+    "    pandas_df = pd.read_csv(filename)\n",
+    "    return pandas_df\n",
+    "\n",
+    "input_data = import_data(DATA_PATH)\n",
+    "input_data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "29f2614c-4f3d-4acb-abd3-dd377a177b3e",
+   "metadata": {},
+   "source": [
+    "### Experimental Factors:\n",
+    "| Treatment    | Target |\n",
+    "| :-------- | :------- |\n",
+    "| DMSO  | Control    |\n",
+    "| VTP50469  | MEN1    |\n",
+    "| PF477736 | Chk1    |\n",
+    "| Jakafi    | JAK1/2    |\n",
+    "| K-975  | TEAD1   |\n",
+    "| VE-821 | ATR    |\n",
+    "| dBET6    | BRD2/3/4   |\n",
+    "\n",
+    "\n",
+    "Our next goal is to make sense of the treatments and targets.  One option is to look for downstream targets of one or more drugs. Another option is to look for the neighborhood or the upstream controllers of an interesting protein, etc."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3472fe7f-026d-4494-b1ed-19de76d48fb4",
+   "metadata": {},
+   "source": [
+    "## 2. How can we look for downstream targets for a drug?  What about upstream controllers of a protein?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ed70f148-6d76-4167-ad89-ca71f2c48501",
+   "metadata": {},
+   "source": [
+    "INDRA (Integrated Network and Dynamical Reasoning Assembler) is an automated model assembly system, originally developed for molecular systems biology and then generalized to other domains (see INDRA World). INDRA draws on natural language processing systems and structured databases to collect mechanistic and causal assertions, represents them in a standardized form (INDRA Statements), and assembles them into various modeling formalisms including causal graphs and dynamical models.\n",
+    "\n",
+    "At the core of INDRA are its knowledge-level assembly procedures, allowing sources to be assembled into coherent models, a process that involves correcting systematic input errors, finding and resolving redundancies, inferring missing information, filtering to a relevant scope and assessing the reliability of causal information.\n",
+    "\n",
+    "The detailed INDRA documentation is available at http://indra.readthedocs.io."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "b2e4e173-2b11-42fc-a9b1-9c82260dda17",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from indra.sources.indra_db_rest.api import get_statements_from_query\n",
+    "from indra.sources.indra_db_rest.query import HasAgent, HasEvidenceBound, HasType\n",
+    "from indra.assemblers.html import HtmlAssembler\n",
+    "from IPython.core.display import HTML"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "78abf8c2-a0c0-4d3f-a9d6-f06a7c004507",
+   "metadata": {},
+   "source": [
+    "For each drug, we can ground their names using gilda.  In this example, we look at the downstream targets of DBET6"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "740636c1-39bf-44aa-b8db-479446403fb0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2024-04-23 19:00:11] indra_db_rest.query_processor - Retrieving statements that have an agent where NAME=dBET6.\n",
+      "INFO: [2024-04-23 19:00:11] indra_db_rest.request_logs - Running 0th request for statements\n",
+      "INFO: [2024-04-23 19:00:11] indra_db_rest.request_logs -   LIMIT: None\n",
+      "INFO: [2024-04-23 19:00:11] indra_db_rest.request_logs -   OFFSET: 0\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Query for https://db.indra.bio/statements/from_agents?subject=dBET6&format=html\n",
+    "query = HasAgent(\"dBET6\", role=\"SUBJECT\")\n",
+    "p = get_statements_from_query(query, sort_by = \"belief\")\n",
+    "\n",
+    "ha = HtmlAssembler(p.statements,\n",
+    "                   title='INDRA subnetwork statements',\n",
+    "                   db_rest_url='https://db.indra.bio',\n",
+    "                   ev_counts=p.get_ev_counts(),\n",
+    "                   source_counts=p.get_source_counts())\n",
+    "html_str = ha.make_model()\n",
+    "# HTML(html_str)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ce072677-d618-4404-90e1-79686e07a800",
+   "metadata": {},
+   "source": [
+    "We can also search based on a namespace + ID combination.  The below query is for the drug Jakafi, which we had determined had the curie chebi:66917 from gilda previously. \n",
+    "\n",
+    "One can also specify an evidence bound to only collect high evidence statements.  For additional query parameters, see [here](https://indra.readthedocs.io/en/latest/modules/sources/indra_db_rest/index.html#indra.sources.indra_db_rest.query.Query)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "bd9cd910-87c7-471e-a43a-4df458c47f89",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2024-04-23 19:07:54] indra_db_rest.query_processor - Retrieving statements that have > 10 evidence and have an agent where CHEBI=66917.\n",
+      "INFO: [2024-04-23 19:07:54] indra_db_rest.request_logs - Running 0th request for statements\n",
+      "INFO: [2024-04-23 19:07:54] indra_db_rest.request_logs -   LIMIT: None\n",
+      "INFO: [2024-04-23 19:07:54] indra_db_rest.request_logs -   OFFSET: 0\n"
+     ]
+    }
+   ],
+   "source": [
+    "query = HasAgent(\"66917\", namespace=\"CHEBI\") & HasEvidenceBound([\"> 10\"])\n",
+    "p = get_statements_from_query(query, sort_by = \"belief\")\n",
+    "\n",
+    "ha = HtmlAssembler(p.statements,\n",
+    "                   title='INDRA subnetwork statements',\n",
+    "                   db_rest_url='https://db.indra.bio',\n",
+    "                   ev_counts=p.get_ev_counts(),\n",
+    "                   source_counts=p.get_source_counts())\n",
+    "html_str = ha.make_model()\n",
+    "# HTML(html_str)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1adbd362-3e7c-4351-903b-1c13d6437a17",
+   "metadata": {},
+   "source": [
+    "We can use a similar query to look for upstream controllers of a protein. In the below example, we look for upstream inhibitors of BRD2.  We should expect to see DBET1 as an inhibitor of BRD2.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "8f764c13-9e45-4f4e-8555-34bc169b9d73",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2024-04-23 19:11:43] indra_db_rest.query_processor - Retrieving statements that have an agent where NAME=BRD2 with role=OBJECT and have type Inhibition.\n",
+      "INFO: [2024-04-23 19:11:43] indra_db_rest.request_logs - Running 0th request for statements\n",
+      "INFO: [2024-04-23 19:11:43] indra_db_rest.request_logs -   LIMIT: None\n",
+      "INFO: [2024-04-23 19:11:43] indra_db_rest.request_logs -   OFFSET: 0\n"
+     ]
+    }
+   ],
+   "source": [
+    "query = (HasAgent(\"BRD2\", role=\"OBJECT\") & HasType([\"Inhibition\"]))\n",
+    "p = get_statements_from_query(query, sort_by = \"belief\")\n",
+    "\n",
+    "ha = HtmlAssembler(p.statements,\n",
+    "                   title='INDRA subnetwork statements',\n",
+    "                   db_rest_url='https://db.indra.bio',\n",
+    "                   ev_counts=p.get_ev_counts(),\n",
+    "                   source_counts=p.get_source_counts())\n",
+    "html_str = ha.make_model()\n",
+    "# HTML(html_str)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "venv2",
+   "language": "python",
+   "name": "venv2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/Module4.ipynb
+++ b/Module4.ipynb
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 1,
    "id": "505a7b3f-bf79-42ff-a82a-8c2e1277a304",
    "metadata": {},
    "outputs": [],
@@ -358,7 +358,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 3,
    "id": "b2e4e173-2b11-42fc-a9b1-9c82260dda17",
    "metadata": {},
    "outputs": [],
@@ -379,7 +379,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 4,
    "id": "740636c1-39bf-44aa-b8db-479446403fb0",
    "metadata": {},
    "outputs": [
@@ -387,10 +387,10 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO: [2024-04-23 19:00:11] indra_db_rest.query_processor - Retrieving statements that have an agent where NAME=dBET6.\n",
-      "INFO: [2024-04-23 19:00:11] indra_db_rest.request_logs - Running 0th request for statements\n",
-      "INFO: [2024-04-23 19:00:11] indra_db_rest.request_logs -   LIMIT: None\n",
-      "INFO: [2024-04-23 19:00:11] indra_db_rest.request_logs -   OFFSET: 0\n"
+      "INFO: [2024-04-25 10:23:28] indra_db_rest.query_processor - Retrieving statements that have an agent where NAME=dBET6 with role=SUBJECT.\n",
+      "INFO: [2024-04-25 10:23:28] indra_db_rest.request_logs - Running 0th request for statements\n",
+      "INFO: [2024-04-25 10:23:28] indra_db_rest.request_logs -   LIMIT: None\n",
+      "INFO: [2024-04-25 10:23:28] indra_db_rest.request_logs -   OFFSET: 0\n"
      ]
     }
    ],
@@ -420,7 +420,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 5,
    "id": "bd9cd910-87c7-471e-a43a-4df458c47f89",
    "metadata": {},
    "outputs": [
@@ -428,10 +428,10 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO: [2024-04-23 19:07:54] indra_db_rest.query_processor - Retrieving statements that have > 10 evidence and have an agent where CHEBI=66917.\n",
-      "INFO: [2024-04-23 19:07:54] indra_db_rest.request_logs - Running 0th request for statements\n",
-      "INFO: [2024-04-23 19:07:54] indra_db_rest.request_logs -   LIMIT: None\n",
-      "INFO: [2024-04-23 19:07:54] indra_db_rest.request_logs -   OFFSET: 0\n"
+      "INFO: [2024-04-25 10:23:33] indra_db_rest.query_processor - Retrieving statements that have > 10 evidence and have an agent where CHEBI=66917.\n",
+      "INFO: [2024-04-25 10:23:33] indra_db_rest.request_logs - Running 0th request for statements\n",
+      "INFO: [2024-04-25 10:23:33] indra_db_rest.request_logs -   LIMIT: None\n",
+      "INFO: [2024-04-25 10:23:33] indra_db_rest.request_logs -   OFFSET: 0\n"
      ]
     }
    ],
@@ -453,12 +453,12 @@
    "id": "1adbd362-3e7c-4351-903b-1c13d6437a17",
    "metadata": {},
    "source": [
-    "We can use a similar query to look for upstream controllers of a protein. In the below example, we look for upstream inhibitors of BRD2.  We should expect to see DBET1 as an inhibitor of BRD2.  "
+    "We can use a similar query to look for upstream controllers of a protein. In the below example, we look for upstream inhibitors of BRD2, BRD3, and BRD4.  We should expect to see DBET1 as an inhibitor of BRD2.  "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 9,
    "id": "8f764c13-9e45-4f4e-8555-34bc169b9d73",
    "metadata": {},
    "outputs": [
@@ -466,15 +466,22 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO: [2024-04-23 19:11:43] indra_db_rest.query_processor - Retrieving statements that have an agent where NAME=BRD2 with role=OBJECT and have type Inhibition.\n",
-      "INFO: [2024-04-23 19:11:43] indra_db_rest.request_logs - Running 0th request for statements\n",
-      "INFO: [2024-04-23 19:11:43] indra_db_rest.request_logs -   LIMIT: None\n",
-      "INFO: [2024-04-23 19:11:43] indra_db_rest.request_logs -   OFFSET: 0\n"
+      "INFO: [2024-04-25 10:24:14] indra_db_rest.query_processor - Retrieving statements that (have an agent where NAME=BRD2 with role=OBJECT, have an agent where NAME=BRD3 with role=OBJECT, or have an agent where NAME=BRD4 with role=OBJECT) and have type Inhibition.\n",
+      "INFO: [2024-04-25 10:24:14] indra_db_rest.request_logs - Running 0th request for statements\n",
+      "INFO: [2024-04-25 10:24:14] indra_db_rest.request_logs -   LIMIT: None\n",
+      "INFO: [2024-04-25 10:24:14] indra_db_rest.request_logs -   OFFSET: 0\n",
+      "INFO: [2024-04-25 10:24:21] indra_db_rest.request_logs - Running 1st request for statements\n",
+      "INFO: [2024-04-25 10:24:21] indra_db_rest.request_logs -   LIMIT: None\n",
+      "INFO: [2024-04-25 10:24:21] indra_db_rest.request_logs -   OFFSET: 500\n",
+      "INFO: [2024-04-25 10:24:25] indra.assemblers.html.assembler - Removing CHEBI from refs due to too many matches: {'CHEBI:95080', 'CHEBI:137113'}\n",
+      "INFO: [2024-04-25 10:24:25] indra.assemblers.html.assembler - Removing UP from refs due to too many matches: {'Q17103', 'P01106'}\n",
+      "INFO: [2024-04-25 10:24:25] indra.assemblers.html.assembler - Removing CHEBI from refs due to too many matches: {'CHEBI:60325', '60325'}\n"
      ]
     }
    ],
    "source": [
-    "query = (HasAgent(\"BRD2\", role=\"OBJECT\") & HasType([\"Inhibition\"]))\n",
+    "query = ((HasAgent(\"BRD2\", role=\"OBJECT\") | HasAgent(\"BRD3\", role=\"OBJECT\") | HasAgent(\"BRD4\", role=\"OBJECT\"))\n",
+    "         & HasType([\"Inhibition\"]))\n",
     "p = get_statements_from_query(query, sort_by = \"belief\")\n",
     "\n",
     "ha = HtmlAssembler(p.statements,\n",


### PR DESCRIPTION
Hey Ben, I think what we have here is enough for querying INDRA in a Python notebook for downstream targets of drugs and upstream controllers of proteins.  Tagging you in this PR for visibility purposes.

## Changes
- Added new python notebook introducing how to use INDRA to query downstream targets of drugs and upstream controllers of proteins.
    - Example 1: query targets of dBET6
    - Example 2: query targets of Jakofi
    - Example 3: query inhibitors of BRD2, BRD3, and BRD4